### PR TITLE
support nested blank nodes in construct head

### DIFF
--- a/sparql/blank_node_bug_test.go
+++ b/sparql/blank_node_bug_test.go
@@ -1,0 +1,38 @@
+package sparql
+
+import (
+	"testing"
+)
+
+func TestConstructNestedBlankNodePropertyList(t *testing.T) {
+	g := makeSPARQLGraph(t)
+	r, err := Query(g, `
+		PREFIX ex: <http://example.org/>
+		CONSTRUCT { 
+			?s ex:details [ ex:contact [ ex:name ?name ; a ex:Name ] ; 
+			                a ex:Contact
+			              ] 
+		}
+		WHERE { 
+			?s ex:name ?name 
+		}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Graph == nil {
+		t.Error("expected graph")
+	}
+
+	// Should produce 5 triples for each person:
+	// ?s ex:details _:bnode1  .
+	// _:bnode1 ex:contact _:bnode2 ;
+	//   a ex:Contact .
+	// _:bnode2 ex:name ?name ;
+	//   a ex:Name .
+	// With 3 people, that's 15 triples total
+	expectedTripleCount := 15
+	if r.Graph.Len() != expectedTripleCount {
+		t.Errorf("expected %d triples, got %d", expectedTripleCount, r.Graph.Len())
+	}
+}

--- a/sparql/parser_lex.go
+++ b/sparql/parser_lex.go
@@ -246,7 +246,25 @@ func (p *sparqlParser) parseBnodePropertyListTriples() (string, []Triple, error)
 		}
 		p.skipWS()
 		for {
-			obj := p.readTermOrVar()
+			p.skipWS()
+			var obj string
+			if p.pos < len(p.input) && p.input[p.pos] == '[' {
+				nestedBnode, extraTriples, err := p.parseBnodePropertyListTriples()
+				if err != nil {
+					return bnode, nil, err
+				}
+				obj = nestedBnode
+				triples = append(triples, extraTriples...)
+			} else if p.pos < len(p.input) && p.input[p.pos] == '(' {
+				head, extraTriples, err := p.parseCollectionTriples()
+				if err != nil {
+					return bnode, nil, err
+				}
+				obj = head
+				triples = append(triples, extraTriples...)
+			} else {
+				obj = p.readTermOrVar()
+			}
 			if obj == "" {
 				break
 			}

--- a/sparql/parser_query.go
+++ b/sparql/parser_query.go
@@ -105,8 +105,21 @@ func (p *sparqlParser) parseConstruct(q *ParsedQuery) error {
 			}
 			continue
 		}
-		s := p.readTermOrVar()
-		flushReifiers()
+		// Handle blank node property lists as subject
+		var s string
+		if p.pos < len(p.input) && p.input[p.pos] == '[' {
+			bnode, bnodeTriples, err := p.parseBnodePropertyListTriples()
+			if err != nil {
+				return err
+			}
+			s = bnode
+			for _, bt := range bnodeTriples {
+				q.Construct = append(q.Construct, TripleTemplate{Subject: bt.Subject, Predicate: bt.Predicate, Object: bt.Object})
+			}
+		} else {
+			s = p.readTermOrVar()
+			flushReifiers()
+		}
 		if s == "" {
 			return p.errorf("unexpected token in CONSTRUCT template")
 		}
@@ -115,8 +128,21 @@ func (p *sparqlParser) parseConstruct(q *ParsedQuery) error {
 		p.skipWS()
 		// Object list (,) and predicate-object list (;)
 		for {
-			obj := p.readTermOrVar()
-			flushReifiers()
+			// Handle blank node property lists as object
+			var obj string
+			if p.pos < len(p.input) && p.input[p.pos] == '[' {
+				bnode, bnodeTriples, err := p.parseBnodePropertyListTriples()
+				if err != nil {
+					return err
+				}
+				obj = bnode
+				for _, bt := range bnodeTriples {
+					q.Construct = append(q.Construct, TripleTemplate{Subject: bt.Subject, Predicate: bt.Predicate, Object: bt.Object})
+				}
+			} else {
+				obj = p.readTermOrVar()
+				flushReifiers()
+			}
 			q.Construct = append(q.Construct, TripleTemplate{Subject: s, Predicate: pred, Object: obj})
 			p.skipWS()
 			// Check for annotation/reifier syntax after object in CONSTRUCT
@@ -139,8 +165,21 @@ func (p *sparqlParser) parseConstruct(q *ParsedQuery) error {
 			pred = p.readTermOrVar()
 			p.skipWS()
 			for {
-				obj := p.readTermOrVar()
-				flushReifiers()
+				// Handle blank node property lists as object in semicolon section
+				var obj string
+				if p.pos < len(p.input) && p.input[p.pos] == '[' {
+					bnode, bnodeTriples, err := p.parseBnodePropertyListTriples()
+					if err != nil {
+						return err
+					}
+					obj = bnode
+					for _, bt := range bnodeTriples {
+						q.Construct = append(q.Construct, TripleTemplate{Subject: bt.Subject, Predicate: bt.Predicate, Object: bt.Object})
+					}
+				} else {
+					obj = p.readTermOrVar()
+					flushReifiers()
+				}
 				q.Construct = append(q.Construct, TripleTemplate{Subject: s, Predicate: pred, Object: obj})
 				p.skipWS()
 				p.parseConstructAnnotations(q, s, pred, obj, rdfReifies)


### PR DESCRIPTION
- adding support for nested blank nodes in the construct template (head).

e.g.

```sh
$ cat a.rq
prefix u: <uri:>
construct {
u:thing  u:a [ u:b [ u:c "apple" ; a u:Type ] ]
}
where {
bind(now() as ?now)
}
$ path_to/apache-jena-5.5.0/bin/sparql --data=a.ttl --query=./a.rq
PREFIX u: <uri:>

u:thing  u:a    [ u:b     [ a       u:Type;
                            u:c     "apple"
                          ]
                ] .
```