### PR TITLE
Add jsonld parsing option for unbounded size and associated tests

### DIFF
--- a/jsonld/jsonld_test.go
+++ b/jsonld/jsonld_test.go
@@ -293,6 +293,23 @@ func TestJSONLDSkipInvalidIRIs(t *testing.T) {
 	}
 }
 
+// TestJSONLDParseNQuadsWithUnboundedLines verifies the JSON-LD parser forwards
+// its unbounded-line option to the intermediate N-Quads parser.
+func TestJSONLDParseNQuadsWithUnboundedLines(t *testing.T) {
+	bigLiteral := strings.Repeat("x", 5*1024*1024)
+	nquads := `<http://example.org/s> <http://example.org/p> "` + bigLiteral + `" .` + "\n"
+
+	g := rdflibgo.NewGraph()
+	var cfg config
+	WithUnboundedLines()(&cfg)
+	if err := parseNQuadsInto(g, nquads, &cfg); err != nil {
+		t.Fatalf("unexpected error with WithUnboundedLines: %v", err)
+	}
+	if g.Len() != 1 {
+		t.Fatalf("expected 1 triple, got %d", g.Len())
+	}
+}
+
 // TestJSONLDSkipInvalidIRIsEndToEnd runs the author's exact example through the
 // public Parse with the option set: it must succeed (it already does on current
 // json-gold, which drops the malformed term itself).

--- a/jsonld/options.go
+++ b/jsonld/options.go
@@ -17,6 +17,7 @@ type config struct {
 	form           OutputForm
 	documentLoader ld.DocumentLoader
 	skipInvalidIRI bool
+	unbounded      bool
 }
 
 // Option configures JSON-LD parsing or serialization.
@@ -53,4 +54,11 @@ func WithDocumentLoader(loader ld.DocumentLoader) Option {
 // option is a safety net for IRIs that slip through to the N-Quads layer.
 func WithSkipInvalidIRIs() Option {
 	return func(c *config) { c.skipInvalidIRI = true }
+}
+
+// WithUnboundedLines parses intermediate N-Quads lines of arbitrary length,
+// growing the read buffer as needed. This is useful when JSON-LD expansion
+// produces very large literal values on a single N-Quads line.
+func WithUnboundedLines() Option {
+	return func(c *config) { c.unbounded = true }
 }

--- a/jsonld/parser.go
+++ b/jsonld/parser.go
@@ -16,7 +16,7 @@ import (
 
 // Parse parses a JSON-LD document into the given graph.
 // It uses piprate/json-gold to expand the document to N-Quads, then parses those into the graph.
-// Options: WithBase, WithDocumentLoader.
+// Options: WithBase, WithDocumentLoader, WithSkipInvalidIRIs, WithUnboundedLines.
 func Parse(g *rdflibgo.Graph, r io.Reader, opts ...Option) error {
 	var cfg config
 	for _, o := range opts {
@@ -62,16 +62,20 @@ func Parse(g *rdflibgo.Graph, r io.Reader, opts ...Option) error {
 // When set, lines that fail because of an invalid IRI (ntsyntax.ErrInvalidIRI)
 // are skipped instead of aborting the parse.
 func parseNQuadsInto(g *rdflibgo.Graph, nqStr string, cfg *config) error {
-	if !cfg.skipInvalidIRI {
-		return nq.Parse(g, strings.NewReader(nqStr))
+	nqOpts := make([]nq.Option, 0, 2)
+	if cfg.unbounded {
+		nqOpts = append(nqOpts, nq.WithUnboundedLines())
 	}
-	skipInvalid := func(lineNum int, line string, err error) (string, bool) {
-		if errors.Is(err, ntsyntax.ErrInvalidIRI) {
-			return "", false // skip this triple, continue parsing
+	if cfg.skipInvalidIRI {
+		skipInvalid := func(lineNum int, line string, err error) (string, bool) {
+			if errors.Is(err, ntsyntax.ErrInvalidIRI) {
+				return "", false // skip this triple, continue parsing
+			}
+			// Re-surface anything that isn't an invalid IRI by re-parsing the
+			// unmodified line, which fails the same way and aborts.
+			return line, true
 		}
-		// Re-surface anything that isn't an invalid IRI by re-parsing the
-		// unmodified line, which fails the same way and aborts.
-		return line, true
+		nqOpts = append(nqOpts, nq.WithErrorHandler(skipInvalid))
 	}
-	return nq.Parse(g, strings.NewReader(nqStr), nq.WithErrorHandler(skipInvalid))
+	return nq.Parse(g, strings.NewReader(nqStr), nqOpts...)
 }

--- a/shacl/jsonld_test.go
+++ b/shacl/jsonld_test.go
@@ -1,7 +1,10 @@
 package shacl
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/tggo/goRDFlib/jsonld"
 )
 
 // jsonldContext is a reusable JSON-LD context for tests.
@@ -1466,6 +1469,27 @@ func TestLoadJsonLDString_Invalid(t *testing.T) {
 	_, err := LoadJsonLDString("not valid json", "http://example.org/")
 	if err == nil {
 		t.Error("expected error for invalid JSON-LD")
+	}
+}
+
+func TestLoadJsonLDString_UnboundedLinesOptIn(t *testing.T) {
+	t.Parallel()
+	data := `{
+  "@context": {"ex": "http://example.org/"},
+  "@id": "ex:Alice",
+  "ex:description": "` + strings.Repeat("x", 5*1024*1024) + `"
+}`
+
+	if _, err := LoadJsonLDString(data, "http://example.org/"); err == nil {
+		t.Fatal("expected large JSON-LD literal to fail without WithUnboundedLines")
+	}
+
+	g, err := LoadJsonLDString(data, "http://example.org/", jsonld.WithUnboundedLines())
+	if err != nil {
+		t.Fatalf("unexpected error loading JSON-LD with large literal: %v", err)
+	}
+	if g.Len() != 1 {
+		t.Fatalf("expected 1 triple, got %d", g.Len())
 	}
 }
 

--- a/shacl/jsonld_test.go
+++ b/shacl/jsonld_test.go
@@ -1493,6 +1493,32 @@ func TestLoadJsonLDString_UnboundedLinesOptIn(t *testing.T) {
 	}
 }
 
+// --- Validate large JSON-LD data ensuring it can be both parsed and validated ---
+
+func TestValidateLargeJsonLD(t *testing.T) {
+	t.Parallel()
+	data := `{
+  "@context": {"ex": "http://example.org/"},
+  "@id": "ex:Alice",
+  "ex:description": "` + strings.Repeat("x", 5*1024*1024) + `"
+}`
+	g, err := LoadJsonLDString(data, "http://example.org/", jsonld.WithUnboundedLines())
+	if err != nil {
+		t.Fatalf("unexpected error loading JSON-LD with large literal: %v", err)
+	}
+	shapes := mustParseWithPrefixes(t, `
+ex:S a sh:NodeShape ;
+    sh:targetNode ex:Alice ;
+    sh:property [
+        sh:path ex:description ;
+        sh:minCount 1 ;
+    ] .
+`)
+	if report := Validate(g, shapes); !report.Conforms {
+		t.Fatalf("expected large JSON-LD data to conform, got %d violations", len(report.Results))
+	}
+}
+
 func TestLoadJsonLDFile_NotFound(t *testing.T) {
 	t.Parallel()
 	_, err := LoadJsonLDFile("/nonexistent/path/to/file.jsonld")

--- a/shacl/rdf.go
+++ b/shacl/rdf.go
@@ -267,7 +267,7 @@ func LoadTurtleString(data, base string) (*Graph, error) {
 }
 
 // LoadJsonLDFile loads a JSON-LD file from disk.
-func LoadJsonLDFile(path string) (*Graph, error) {
+func LoadJsonLDFile(path string, opts ...jsonld.Option) (*Graph, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -275,24 +275,28 @@ func LoadJsonLDFile(path string) (*Graph, error) {
 	defer f.Close()
 	base := "file://" + path
 	g := graph.NewGraph(graph.WithBase(base))
-	if err := jsonld.Parse(g, f, jsonld.WithBase(base)); err != nil {
+	parseOpts := append([]jsonld.Option{}, opts...)
+	parseOpts = append(parseOpts, jsonld.WithBase(base))
+	if err := jsonld.Parse(g, f, parseOpts...); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 	return &Graph{g: g, baseURI: base}, nil
 }
 
 // LoadJsonLD parses JSON-LD data from a reader.
-func LoadJsonLD(r io.Reader, base string) (*Graph, error) {
+func LoadJsonLD(r io.Reader, base string, opts ...jsonld.Option) (*Graph, error) {
 	g := graph.NewGraph(graph.WithBase(base))
-	if err := jsonld.Parse(g, r, jsonld.WithBase(base)); err != nil {
+	parseOpts := append([]jsonld.Option{}, opts...)
+	parseOpts = append(parseOpts, jsonld.WithBase(base))
+	if err := jsonld.Parse(g, r, parseOpts...); err != nil {
 		return nil, err
 	}
 	return &Graph{g: g, baseURI: base}, nil
 }
 
 // LoadJsonLDString parses JSON-LD data from a string.
-func LoadJsonLDString(data, base string) (*Graph, error) {
-	return LoadJsonLD(strings.NewReader(data), base)
+func LoadJsonLDString(data, base string, opts ...jsonld.Option) (*Graph, error) {
+	return LoadJsonLD(strings.NewReader(data), base, opts...)
 }
 
 // LoadNQuadsFile loads an N-Quads file from disk.


### PR DESCRIPTION
Thank you for the great work on goRDFlib!

Currently the Jsonld parser functions in the shacl package parse the Jsonld and then convert the Jsonld to nquads. It seems the Jsonld parser allows for arbitrary size data, but the nquad parser does not expose a setting to allow for arbitrarily sized data. This PR exposes the `...opts` to the JsonLD parsing functions that allows large Jsonld to be parsed. It also adds some extra tests to ensure this size constraint is tested. 

